### PR TITLE
Fix gmx rbdihedral

### DIFF
--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -374,7 +374,7 @@ class AmberParm(AmberFormat, Structure):
         # present as a way to hack entries into the 1-4 pairlist. See
         # https://github.com/ParmEd/ParmEd/pull/145 for discussion. The solution
         # here is to simply set that periodicity to 1.
-        self._cleanup_dihedrals_with_periodicity_zero()
+        inst._cleanup_dihedrals_with_periodicity_zero()
         inst.remake_parm()
         inst._set_nonbonded_tables(nbfixes)
         n_copy = inst.pointers.get('NCOPY', 1)

--- a/parmed/amber/_amberparm.py
+++ b/parmed/amber/_amberparm.py
@@ -2111,7 +2111,8 @@ class AmberParm(AmberFormat, Structure):
         pmemd will always get that exception correct
         """
         dt = None
-        for dih in self.dihedral_types:
+        new_dihedrals = []
+        for dih in self.dihedrals:
             if dih.ignore_end or dih.type.per != 0:
                 continue
             # If we got here, ignore_end must be False and out periodicity must be 0. So add
@@ -2119,13 +2120,15 @@ class AmberParm(AmberFormat, Structure):
             if dt is None:
                 dt = DihedralType(0, 1, 0, dih.type.scee, dih.type.scnb, list=self.dihedral_types)
                 self.dihedral_types.append(dt)
-            self.dihedrals.append(
+            new_dihedrals.append(
                 Dihedral(dih.atom1, dih.atom2, dih.atom3, dih.atom4, improper=dih.improper,
-                         ignore_end=False)
+                         ignore_end=False, type=dt)
             )
             # Now that we added the above dihedral, we can start ignoring the end-group interactions
             # on this dihedral
             dih.ignore_end = True
+        if new_dihedrals:
+            self.dihedrals.extend(new_dihedrals)
 
     #===================================================
 

--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -21,31 +21,34 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 59 Temple Place - Suite 330
 Boston, MA 02111-1307, USA.
 """
-from __future__ import division, print_function
+from __future__ import absolute_import, division, print_function
 
+import math
+import os
 from collections import defaultdict
 from copy import copy
-import math
+
 import numpy as np
-import os
-from parmed.constants import DEG_TO_RAD, SMALL
-from parmed.exceptions import ParameterError
-from parmed.geometry import (box_lengths_and_angles_to_vectors,
-        box_vectors_to_lengths_and_angles, STANDARD_BOND_LENGTHS_SQUARED,
-        distance2)
-from parmed.topologyobjects import (AtomList, ResidueList, TrackedList,
-        DihedralTypeList, Bond, Angle, Dihedral, UreyBradley, Improper, Cmap,
-        TrigonalAngle, OutOfPlaneBend, PiTorsion, StretchBend, TorsionTorsion,
-        NonbondedException, AcceptorDonor, Group, ExtraPoint, ChiralFrame,
-        TwoParticleExtraPointFrame, MultipoleFrame, NoUreyBradley, Atom,
-        ThreeParticleExtraPointFrame, OutOfPlaneExtraPointFrame,
-        UnassignedAtomType)
-from parmed import unit as u, residue
-from parmed.utils import tag_molecules, PYPY, find_atom_pairs
-from parmed.utils.decorators import needs_openmm
-from parmed.utils.six import string_types, integer_types, iteritems
-from parmed.utils.six.moves import zip, range
-from parmed.vec3 import Vec3
+
+from . import unit as u
+from . import residue
+from .constants import DEG_TO_RAD, SMALL
+from .exceptions import ParameterError
+from .geometry import (STANDARD_BOND_LENGTHS_SQUARED, box_lengths_and_angles_to_vectors,
+                       box_vectors_to_lengths_and_angles, distance2)
+from .topologyobjects import (AcceptorDonor, Angle, Atom, AtomList, Bond, ChiralFrame, Cmap,
+                              Dihedral, DihedralType, DihedralTypeList, ExtraPoint, Group, Improper,
+                              MultipoleFrame, NonbondedException, NoUreyBradley, OutOfPlaneBend,
+                              OutOfPlaneExtraPointFrame, PiTorsion, ResidueList, StretchBend,
+                              ThreeParticleExtraPointFrame, TorsionTorsion, TrackedList,
+                              TrigonalAngle, TwoParticleExtraPointFrame, UnassignedAtomType,
+                              UreyBradley)
+from .utils import PYPY, find_atom_pairs, tag_molecules
+from .utils.decorators import needs_openmm
+from .utils.six import integer_types, iteritems, string_types
+from .utils.six.moves import range, zip
+from .vec3 import Vec3
+
 # Try to import the OpenMM modules
 try:
     from simtk.openmm import app
@@ -780,7 +783,10 @@ class Structure(object):
             elif (dihedral.atom1.idx, dihedral.atom4.idx) in set14:
                 # Avoid double counting of 1-4 in a six-membered ring
                 dihedral.ignore_end = True
-            elif dihedral.type is not None and dihedral.type.per == 0:
+            elif isinstance(dihedral.type, DihedralType) and dihedral.type.per == 0:
+                # This needs to be done to work around a "feature" in pmemd where periodicity=0
+                # torsions are thrown away. Since AmberParm never has any DihedralTypeList, we only
+                # need to defer periodicity=0 torsions for DihedralType torsions.
                 deferred_dihedrals.append(dihedral)
             else:
                 set14.add((dihedral.atom1.idx, dihedral.atom4.idx))


### PR DESCRIPTION
This is the last failure I get after this change:

```
======================================================================
FAIL: Check equal energies for Gromacs -> Amber conversion of Amber FF
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/swails/src/ParmEd/test/test_format_conversions.py", line 339, in test_unconvertable_rb_torsion
    self.check_energies(top, cong, parm, cona)
  File "/home/swails/src/ParmEd/test/utils.py", line 89, in check_energies
    self.assertRelativeEqual(ene2[term], ene1[term], places=5)
  File "/home/swails/src/ParmEd/test/utils.py", line 68, in assertRelativeEqual
    (val1, val2, 10**-places, ratio))
AssertionError: 1.4346490265009522 != 1.3917329149832047 with relative tolerance 1e-05 (1.030836)

----------------------------------------------------------------------
Ran 855 tests in 822.751s

FAILED (SKIP=27, failures=1)
```

Any ideas here?